### PR TITLE
Error handling with less amount of boiler plate using reflection

### DIFF
--- a/src/main/scala/backend/DomainErrors.scala
+++ b/src/main/scala/backend/DomainErrors.scala
@@ -1,11 +1,20 @@
 package backend
 
-sealed abstract class ErrorResponse(message: String)
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{ConfiguredEncoder, ConfiguredDecoder, Configuration}
 
-sealed case class StorageError(message: String) extends ErrorResponse(message)
-object StorageNotFound:
-  def apply(): StorageError = StorageError("Storage not found")
+given Configuration = Configuration.default.withDiscriminator("type")
+given Encoder[ErrorResponse] = ConfiguredEncoder.derived
+given Decoder[ErrorResponse] = ConfiguredDecoder.derived
 
-sealed case class IngredientError(message: String) extends ErrorResponse(message)
-object IngredientNotFound:
-  def apply(): IngredientError = IngredientError("Ingredient not found")
+sealed trait ErrorResponse:
+  def message: String
+
+sealed trait IngredientError extends ErrorResponse
+sealed trait StorageError extends ErrorResponse
+
+final case class IngredientNotFound(id: IngredientId) extends IngredientError:
+  override def message: String = s"Ingredient with id = $id is not found"
+
+final case class StorageNotFound(id: StorageId) extends StorageError:
+  override def message: String = s"Storage with id = $id is not found"

--- a/src/main/scala/backend/EndpointServerLogic.scala
+++ b/src/main/scala/backend/EndpointServerLogic.scala
@@ -6,7 +6,7 @@ val createIngredient: Ingredient => UIO[Unit] =
   case Ingredient(ingredientId, ingredientName) => ZIO.succeed(())
 
 val getIngredient: IngredientId => IO[IngredientError, Ingredient] =
-  ingredientId => ZIO.fail(IngredientNotFound())
+  id => ZIO.fail(IngredientNotFound(id))
 
 val getAllIngredients: UIO[List[Ingredient]] =
   ZIO.succeed(Nil)

--- a/src/main/scala/backend/Endpoints.scala
+++ b/src/main/scala/backend/Endpoints.scala
@@ -13,8 +13,7 @@ object Endpoints:
   private def matchErrorWithStatusCode[T <: ErrorResponse: ClassTag](statusCode: StatusCode,
                                                                      output: EndpointOutput[ErrorResponse]) =
     oneOfVariantValueMatcher(statusCode, output) {
-      case e if implicitly[ClassTag[T]].runtimeClass.isInstance(e) => true
-      case _ => false
+      implicitly[ClassTag[T]].runtimeClass.isInstance(_)
     }
 
   private val createIngredientsEndpoint = endpoint

--- a/src/main/scala/backend/Endpoints.scala
+++ b/src/main/scala/backend/Endpoints.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 object Endpoints:
   private def matchErrorWithStatusCode[T <: ErrorResponse: ClassTag](statusCode: StatusCode,
                                                                      output: EndpointOutput[ErrorResponse]) =
-    oneOfVariantValueMatcher(statusCode, jsonBody[ErrorResponse]) {
+    oneOfVariantValueMatcher(statusCode, output) {
       case e if implicitly[ClassTag[T]].runtimeClass.isInstance(e) => true
       case _ => false
     }


### PR DESCRIPTION
**Pros**: No need for tons of codecs, provide just one for the base error class
**Cons**: Using of reflection may be ambiguous, forced using of loose type annotations in tapir endpoints instead of fine-grained (e. g. `oneOf[ErrorResponse]` instead of `oneOf[IngredientError | StorageError]`)

